### PR TITLE
Added version command, mainly as an example

### DIFF
--- a/src/main/java/com/linuxmasterrace/townvalds/Townvalds.java
+++ b/src/main/java/com/linuxmasterrace/townvalds/Townvalds.java
@@ -1,6 +1,8 @@
 package com.linuxmasterrace.townvalds;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
 
 public class Townvalds extends JavaPlugin {
 	@Override
@@ -11,5 +13,26 @@ public class Townvalds extends JavaPlugin {
 	
 	public void onDisable() {
 		// TODO Insert logic to be performed when the plugin is disabled
+	}
+	
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+		if (cmd.getName().equalsIgnoreCase("townvalds")) {
+			if (args.length == 0) {
+				sender.sendMessage("Usage: /townvalds <argument>\nYou're missing an argument!");
+			}
+			else {			
+				if (args[0].equalsIgnoreCase("version")) {
+					getLogger().info("Townvalds version " + this.getDescription().getVersion());
+				}
+				else {
+					sender.sendMessage("Invalid argument");
+				}
+			}
+			
+			return true;
+		}
+		
+		return false;
 	}
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,3 +1,10 @@
 name: Townvalds
 main: com.linuxmasterrace.townvalds.Townvalds
 version: 0.0.1
+
+commands:
+  townvalds:
+    description: Returns the plugin version
+    usage: /townvalds
+    permission: townvalds.version
+    permission-message: You don't have permission!


### PR DESCRIPTION
Added a version command, which returns the plugin version retrieved from plugin.yml. This is mainly intended as an example on how to use commands in Bukkit.