### PR TITLE
Updated pom.xml to use Spigot as a Maven dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,5 +16,10 @@
 	      <artifactId>spigot-api</artifactId>
 	      <version>1.8.6-R0.1-SNAPSHOT</version>
 	  </dependency>
+	  <dependency>
+	      <groupId>org.bukkit</groupId>
+	      <artifactId>bukkit</artifactId>
+	      <version>1.8.6-R0.1-SNAPSHOT</version>
+	  </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,4 +3,18 @@
   <groupId>com.linuxmasterrace</groupId>
   <artifactId>Townvalds</artifactId>
   <version>0.0.1</version>
+  
+  <repositories>
+    <repository>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/groups/public/org/spigotmc/spigot-api/</url>
+    </repository>
+  </repositories>
+  <dependencies>
+	  <dependency>
+	      <groupId>org.spigotmc</groupId>
+	      <artifactId>spigot-api</artifactId>
+	      <version>1.8.6-R0.1-SNAPSHOT</version>
+	  </dependency>
+  </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,18 +7,13 @@
   <repositories>
     <repository>
       <id>spigot-repo</id>
-      <url>https://hub.spigotmc.org/nexus/content/groups/public/org/spigotmc/spigot-api/</url>
+      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
     </repository>
   </repositories>
   <dependencies>
 	  <dependency>
 	      <groupId>org.spigotmc</groupId>
 	      <artifactId>spigot-api</artifactId>
-	      <version>1.8.6-R0.1-SNAPSHOT</version>
-	  </dependency>
-	  <dependency>
-	      <groupId>org.bukkit</groupId>
-	      <artifactId>bukkit</artifactId>
 	      <version>1.8.6-R0.1-SNAPSHOT</version>
 	  </dependency>
   </dependencies>

--- a/src/main/java/com/linuxmasterrace/townvalds/Townvalds.java
+++ b/src/main/java/com/linuxmasterrace/townvalds/Townvalds.java
@@ -25,7 +25,7 @@ public class Townvalds extends JavaPlugin {
 				if (args[0].equalsIgnoreCase("version")) {
 					getLogger().info("Townvalds version " + this.getDescription().getVersion());
 				}
-				else {
+				else { 
 					sender.sendMessage("Invalid argument");
 				}
 			}


### PR DESCRIPTION
Updated pom.xml to use Spigot as a Maven dependency instead of having it in the build path.
It now builds against Spigot and Bukkit 1.8.6-R0.1-SNAPSHOT