### PR TITLE
Keep the database open all the time

### DIFF
--- a/src/database.lua
+++ b/src/database.lua
@@ -11,7 +11,6 @@ function CreateDatabase()
 end
 
 function ExecuteStatement(sql, parameters)
-	local db = sqlite3.open(PLUGIN:GetLocalFolder() .. "/database.sqlite3");
 	local stmt = db:prepare(sql);
 	local result;
 
@@ -37,8 +36,6 @@ function ExecuteStatement(sql, parameters)
 	if (sql:match("INSERT")) then
 		result = db:last_insert_rowid();
 	end
-
-	db:close();
 
 	if not (result == nil) then
 		return result;

--- a/src/main.lua
+++ b/src/main.lua
@@ -16,16 +16,19 @@ function Initialize(Plugin)
 	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_JOINED, OnPlayerJoined)
 	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_MOVING, OnPlayerMoving)
 	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_DESTROYED, OnPlayerDestroyed)
-        cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_SPAWNED, OnPlayerSpawned)
+    cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_SPAWNED, OnPlayerSpawned)
 
 	if not (cFile:IsFile(PLUGIN:GetLocalFolder() .. "/database.sqlite3")) then -- If true, means database is deleted, or the plugin runs for the first time
 		LOG("[" .. PLUGIN:GetName() .. "] It looks like this is the first time running this plugin. Creating database...")
 		CreateDatabase()
 	end
 
+    db = sqlite3.open(PLUGIN:GetLocalFolder() .. "/database.sqlite3");
+
 	return true
 end
 
 function OnDisable() -- Gets called when the plugin is unloaded, mostly when shutting down the server
-	LOG("[" .. PLUGIN:GetName() .. "] Disabling " .. PLUGIN:GetName() .. " v" .. PLUGIN:GetVersion())
+   LOG("[" .. PLUGIN:GetName() .. "] Disabling " .. PLUGIN:GetName() .. " v" .. PLUGIN:GetVersion())
+   db:close()
 end


### PR DESCRIPTION
This makes the database be opened at initialisation of the plugin an close when disabling the plugin, instead of opening it before and closing it after each statement.
