### PR TITLE
Added functionality to invite players to towns, and then join them

### DIFF
--- a/src/Info.lua
+++ b/src/Info.lua
@@ -52,6 +52,18 @@ g_PluginInfo =
 					Handler = TownUnclaim,
 					HelpString = "Unclaims a chunk for the current town",
 					Permission = "townvalds.town.unclaim",
+				},
+				add =
+				{
+					Handler = TownAddPlayer,
+					HelpString = "Invites a player to a town",
+					Permission = "townvalds.town.add",
+				},
+				join =
+				{
+					Handler = TownJoin,
+					HelpString = "If the player has an invitation of the specified town, this joins that town",
+					Permission = "townvalds.town.join",
 				}
 			}
 		},

--- a/src/Info.lua
+++ b/src/Info.lua
@@ -64,6 +64,12 @@ g_PluginInfo =
 					Handler = TownJoin,
 					HelpString = "If the player has an invitation of the specified town, this joins that town",
 					Permission = "townvalds.town.join",
+				},
+				leave =
+				{
+					Handler = TownLeave,
+					HelpString = "Leave the current town",
+					Permission = "townvalds.town.leave",
 				}
 			}
 		},

--- a/src/config.lua
+++ b/src/config.lua
@@ -1,18 +1,25 @@
 config = {};
 
 function LoadConfig()
-   local newconfig = {};
-   ini:ReadFile(PLUGIN:GetLocalFolder() .. "/config.ini");
-   ini:DeleteHeaderComments();
-   ini:AddHeaderComment("Configuration for Townvalds");
+	local newconfig = {};
+	ini:ReadFile(PLUGIN:GetLocalFolder() .. "/config.ini");
+	ini:DeleteHeaderComments();
+	ini:AddHeaderComment("Configuration for Townvalds");
 
-   if not (ini:FindKey("General")) then
-      ini:AddKeyName("General");
-   end
+ 	if not (ini:FindKey("General")) then
+		ini:AddKeyName("General");
+	elseif not (ini:FindKey("Towns")) then
+		ini:AddKeyName("Towns");
+	end
    ini:DeleteKeyComments("General");
-   ini:AddKeyComment("General", "dbname - Filename of the database. REQUIRES PLUGIN RELOAD");
+   ini:DeleteKeyComments("Towns");
 
+   ini:AddKeyComment("General", "dbname - Filename of the database. REQUIRES PLUGIN RELOAD");
    newconfig.dbname = ini:GetValueSet("General", "dbname", "database.sqlite3");
+
+   ini:AddKeyComment("Towns", "invitation_duration - The time an invitation stays valid, in seconds.");
+   ini:AddKeyComment("Towns", "If no expiration is wanted, set it to 0");
+   newconfig.invitation_duration = ini:GetValueSet("Towns", "invitation_duration", "0");
 
    ini:WriteFile(PLUGIN:GetLocalFolder() .. "/config.ini");
    config = newconfig;

--- a/src/database.lua
+++ b/src/database.lua
@@ -4,6 +4,7 @@ function CreateDatabase()
 	sqlCreate[1] = "CREATE TABLE IF NOT EXISTS towns (town_id INTEGER PRIMARY KEY, town_name STRING, town_owner STRING)";
 	sqlCreate[2] = "CREATE TABLE IF NOT EXISTS townChunks (townChunk_id INTEGER PRIMARY KEY, town_id INTEGER, chunkX INTEGER, chunkZ INTEGER)";
 	sqlCreate[3] = "CREATE TABLE IF NOT EXISTS residents (player_uuid STRING UNIQUE, player_name STRING UNIQUE, town_id INTEGER, town_rank STRING, last_online INTEGER)";
+	sqlCreate[4] = "CREATE TABLE IF NOT EXISTS invitations (invitation_id INTEGER PRIMARY KEY, player_uuid STRING, town_id INTEGER)";
 
 	for key in pairs(sqlCreate) do
 		ExecuteStatement(sqlCreate[key]);

--- a/src/database.lua
+++ b/src/database.lua
@@ -4,7 +4,7 @@ function CreateDatabase()
 	sqlCreate[1] = "CREATE TABLE IF NOT EXISTS towns (town_id INTEGER PRIMARY KEY, town_name STRING, town_owner STRING)";
 	sqlCreate[2] = "CREATE TABLE IF NOT EXISTS townChunks (townChunk_id INTEGER PRIMARY KEY, town_id INTEGER, chunkX INTEGER, chunkZ INTEGER)";
 	sqlCreate[3] = "CREATE TABLE IF NOT EXISTS residents (player_uuid STRING UNIQUE, player_name STRING UNIQUE, town_id INTEGER, town_rank STRING, last_online INTEGER)";
-	sqlCreate[4] = "CREATE TABLE IF NOT EXISTS invitations (invitation_id INTEGER PRIMARY KEY, player_uuid STRING, town_id INTEGER)";
+	sqlCreate[4] = "CREATE TABLE IF NOT EXISTS invitations (invitation_id INTEGER PRIMARY KEY, player_uuid STRING, town_id INTEGER, invitation_date DATETIME DEFAULT CURRENT_TIMESTAMP)";
 
 	for key in pairs(sqlCreate) do
 		ExecuteStatement(sqlCreate[key]);

--- a/src/functions.lua
+++ b/src/functions.lua
@@ -68,6 +68,14 @@ function GetTownId(town_name)
     end
 end
 
+function GetTimestampFromString(timestring) --Returns the Lua timestamp from a string which is formatted as "YYYY-mm-dd HH:MM:SS"
+	local pattern = "(%d+)-(%d+)-(%d+) (%d+):(%d+):(%d+)";
+	local year, month, day, hour, minute, second = timestring:match(pattern);
+	local convertedTimestamp = os.time({year = year, month = month, day = day, hour = hour, min = minute, sec = second});
+
+	return convertedTimestamp;
+end
+
 function OnPlayerJoined(Player)
     local sql = "INSERT OR IGNORE INTO residents (player_uuid, player_name, town_id, town_rank, last_online) VALUES (?, ?, NULL, NULL, datetime(\"now\"))";
     local parameters = {cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true), Player:GetName()};

--- a/src/functions.lua
+++ b/src/functions.lua
@@ -34,10 +34,38 @@ end
 
 function GetPlayerTown(UUID)
     sql = "SELECT town_id FROM residents WHERE player_uuid = ?";
-    parameters = {UUID}
-    local town_id = ExecuteStatement(sql, parameters)[1][1];
+    parameters = {UUID};
+    local result = ExecuteStatement(sql, parameters);
 
-    return town_id;
+    if (result[1] and result[1][1]) then
+        return result[1][1];
+    else
+        return nil;
+    end
+end
+
+function GetTownName(town_id)
+    sql = "SELECT town_name FROM towns WHERE town_id = ?";
+    parameters = {town_id};
+    local result = ExecuteStatement(sql, parameters);
+
+    if(result[1] and result[1][1]) then
+        return result[1][1];
+    else
+        return nil;
+    end
+end
+
+function GetTownId(town_name)
+    sql = "SELECT town_id FROM towns WHERE town_name = ?";
+    parameters = {town_name};
+    local result = ExecuteStatement(sql, parameters);
+
+    if(result[1] and result[1][1]) then
+        return result[1][1];
+    else
+        return nil;
+    end
 end
 
 function OnPlayerJoined(Player)

--- a/src/towns.lua
+++ b/src/towns.lua
@@ -144,15 +144,17 @@ function TownJoin(Split, Player)
             Player:SendMessageFailure("You have no invitations!");
 
             return true;
-        elseif not(result[2] == nil) then
-            Player:SendMessageFailure("You have multiple invitations, please specify which one you want to join:");
-            for key, value in pairs(result) do
-                Player:SendMessageInfo(GetTownName(value[1]));
-            end
-
-            return true;
         else
-            town_id = result[1];
+            if not(result[2] == nil) then
+                Player:SendMessageFailure("You have multiple invitations, please specify which one you want to join:");
+                for key, value in pairs(result) do
+                    Player:SendMessageInfo(GetTownName(value[1]));
+                end
+
+                return true;
+            else
+                town_id = result[1][1];
+            end
         end
     else
         town_id = GetTownId(Split[3]);
@@ -167,6 +169,24 @@ function TownJoin(Split, Player)
     ExecuteStatement(sql, parameters);
 
     Player:SendMessageSuccess("You succesfully joined the town!");
+
+    return true;
+end
+
+function TownLeave(Split, Player)
+    sql = "SELECT town_id FROM residents WHERE player_uuid = ?";
+    parameter = {cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true)};
+    local result = ExecuteStatement(sql, parameter);
+
+    if(result[1] and result[1][1]) then
+        sql = "UPDATE residents SET town_id = ? WHERE player_uuid = ?";
+        parameters = {nil, cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true)};
+        ExecuteStatement(sql, parameters);
+
+        Player:SendMessageInfo("You left the town " .. GetTownName(result[1][1]));
+    else
+        Player:SendMessageFailure("You can't leave a town if you're not in one.");
+    end
 
     return true;
 end


### PR DESCRIPTION
Players can now be invited with `/town add (playername)`.
Players can then accept invitations by using `/town join {townname}`. If the user doesn't specify a town, and he has multiple invitations, the plugin will list a list of invitations instead.
