### PR TITLE
Added functionality to assign ranks to residents, or remove them

### DIFF
--- a/src/Info.lua
+++ b/src/Info.lua
@@ -77,11 +77,17 @@ g_PluginInfo =
 					HelpString = "Changes properties of the current town",
 					Permission = "townvalds.town.toggle",
 				},
-				list = 
+				list =
 				{
 					Handler = TownList,
 					HelpString = "Lists towns",
 					Permission = "townvalds.town.list",
+				},
+				rank =
+				{
+					Handler = TownRank,
+					HelpString = "Lists available ranks, or grant and remove a rank to a resident of the town",
+					Permission = "townvalds.town.rank",
 				},
 			}
 		},
@@ -141,18 +147,23 @@ g_PluginInfo =
 		},
 		["townvalds.town.new"] =
 		{
-			Discription = "Allows the player to create a new town",
+			Description = "Allows the player to create a new town",
 			RecommendedGroups = "default",
 		},
 		["townvalds.town.claim"] =
 		{
-			Discription = "Allows the player to claim a new chunk for the town",
+			Description = "Allows the player to claim a new chunk for the town",
 			RecommendedGroups = "default",
 		},
 		["townvalds.town.unclaim"] =
 		{
-			Discription = "Allows the player to unclaim a chunk for the town",
+			Description = "Allows the player to unclaim a chunk for the town",
 			RecommendedGroups = "default",
 		},
+		["townvalds.town.rank"] =
+		{
+			Description = "Lists available ranks, or grant and remove a rank to a resident of the town",
+			RecommendedGroups = "default",
+		}
 	},
 }

--- a/src/functions.lua
+++ b/src/functions.lua
@@ -121,3 +121,12 @@ function CreateTable()
 
     return true;
 end
+
+function Set(list)
+	local set = {};
+	for _, l in ipairs(list) do
+		set[l] = true;
+	end
+
+	return set;
+end

--- a/src/towns.lua
+++ b/src/towns.lua
@@ -307,9 +307,9 @@ function TownRank(Split, Player)
 
 									Player:SendMessageSuccess("Rank granted to the player!");
 								else
-									sql = "UPDATE residents SET town_rank = ? WHERE player_uuid = ?";
-									parameters = {nil, player_uuid};
-									ExecuteStatement(sql, parameters);
+									sql = "UPDATE residents SET town_rank = NULL WHERE player_uuid = ?";
+									parameter = {player_uuid};
+									ExecuteStatement(sql, parameter);
 
 									Player:SendMessageSuccess("Rank removed from the player!");
 								end


### PR DESCRIPTION
Using `/town rank (list/add/remove) {rank} {playername}` a rank can now be assigned or removed, or a list of available ranks be shown.

For now only the rank "assistent" is added, and no other commands check the players rank yet.
