### PR TITLE
Fix sql param in residents.lua

### DIFF
--- a/src/residents.lua
+++ b/src/residents.lua
@@ -15,7 +15,7 @@ function DisplayResident(Split, Player)
 
    -- Query the resident info from the database
    local sql = "SELECT residents.player_name, towns.town_name, residents.town_rank, residents.last_online FROM residents LEFT JOIN towns ON towns.town_id = residents.town_id WHERE residents.player_name = ?"
-   local parameters = {Player:GetName()}
+   local parameters = {Split[2]}
    local result = ExecuteStatement(sql, parameters)
 
    if(result==nil) then


### PR DESCRIPTION
This replaces an incorrect SQL parameter to attempt to fix Issue #17

The parameter passed causes the player's own residency status to displayed instead of the player specified in the /resident command.
