### PR TITLE
Added nations

### DIFF
--- a/src/Info.lua
+++ b/src/Info.lua
@@ -31,6 +31,30 @@ g_PluginInfo =
 				}
 			}
 		},
+		["/nation"] =
+		{
+			Subcommands =
+			{
+				new =
+				{
+					Handler = NationCreate,
+					HelpString = "Creates a new nation",
+					Permission = "townvalds.nation.new",
+				},
+				leave =
+				{
+					Handler = NationLeave,
+					HelpString = "Removes the town from the nation",
+					Permission = "townvalds.nation.leave",
+				},
+				list =
+				{
+					Handler = NationList,
+					HelpString = "Prints a list of all nations",
+					Permission = "townvalds.nation.list",
+				}
+			}
+		},
 		["/town"] =
 		{
 			Subcommands =
@@ -81,12 +105,12 @@ g_PluginInfo =
 							HelpString = "Toggles explosions in the current town",
 							Permission = "townvalds.town.toggle"
 						},
-                        pvp =
-                        {
-                            Handler = TownTogglePVP,
-                            HelpString = "Toggles PVP in the current town",
-                            Permission = "townvalds.town.toggle"
-                        }
+						pvp =
+						{
+							Handler = TownTogglePVP,
+							HelpString = "Toggles PVP in the current town",
+							Permission = "townvalds.town.toggle"
+						}
 					}
 				},
 				list =
@@ -163,6 +187,21 @@ g_PluginInfo =
 		{
 			Description = "Allows the player to view information about a resident",
 			RecommendedGroups = "admins",
+		},
+		["townvalds.nation.list"] =
+		{
+			Description = "Allows the player to see a list of existing nations",
+			RecommendedGroups = "default",
+		},
+		["townvalds.nation.new"] =
+		{
+			Description = "Allows the player to create a new nation",
+			RecommendedGroups = "default",
+		},
+		["townvalds.nation.leave"] =
+		{
+			Description = "Allows the player to remove his/her town from a nnation",
+			RecommendedGroups = "default",
 		},
 		["townvalds.town.new"] =
 		{

--- a/src/config.lua
+++ b/src/config.lua
@@ -9,6 +9,9 @@ function LoadConfig()
 	if not (ini:FindKey("General")) then
 		ini:AddKeyName("General");
 	end
+	if not (ini:FindKey("Nations")) then
+		ini:AddKeyName("Nations");
+	end
 	if not (ini:FindKey("Towns")) then
 		ini:AddKeyName("Towns");
 	end
@@ -27,7 +30,6 @@ function LoadConfig()
 	ini:AddKeyComment("Towns", "If no expiration is wanted, set it to 0");
 	ini:AddKeyComment("Towns", "");
 	newconfig.invitation_duration = ini:GetValueSet("Towns", "invitation_duration", "0");
-
 	ini:AddKeyComment("Towns", "min_distance_from_other_towns - The minimum amount of chunks a new town has to be from existing towns");
 	newconfig.min_distance_from_other_towns = ini:GetValueSetI("Towns", "min_distance_from_other_towns", "5");
 

--- a/src/database.lua
+++ b/src/database.lua
@@ -1,10 +1,11 @@
 function CreateDatabase()
 	-- Create tables
 	local sqlCreate = {};
-	sqlCreate[1] = "CREATE TABLE IF NOT EXISTS towns (town_id INTEGER PRIMARY KEY, town_name STRING, town_owner STRING, town_explosions_enabled INTEGER, town_pvp_enabled INTEGER)";
+	sqlCreate[1] = "CREATE TABLE IF NOT EXISTS towns (town_id INTEGER PRIMARY KEY AUTOINCREMENT, town_name STRING NOT NULL UNIQUE, town_owner STRING NOT NULL UNIQUE, nation_id INTEGER, town_explosions_enabled INTEGER, town_pvp_enabled INTEGER)";
 	sqlCreate[2] = "CREATE TABLE IF NOT EXISTS townChunks (townChunk_id INTEGER PRIMARY KEY, town_id INTEGER, chunkX INTEGER, chunkZ INTEGER)";
 	sqlCreate[3] = "CREATE TABLE IF NOT EXISTS residents (player_uuid STRING UNIQUE, player_name STRING UNIQUE, town_id INTEGER, town_rank STRING, last_online INTEGER)";
-	sqlCreate[4] = "CREATE TABLE IF NOT EXISTS invitations (invitation_id INTEGER PRIMARY KEY, player_uuid STRING, town_id INTEGER, invitation_date DATETIME DEFAULT CURRENT_TIMESTAMP)";
+	sqlCreate[4] = "CREATE TABLE IF NOT EXISTS nations (nation_id INTEGER PRIMARY KEY AUTOINCREMENT, nation_name TEXT NOT NULL UNIQUE, nation_capital INTEGER NOT NULL UNIQUE)"
+	sqlCreate[5] = "CREATE TABLE IF NOT EXISTS invitations (invitation_id INTEGER PRIMARY KEY, player_uuid STRING, town_id INTEGER, invitation_date DATETIME DEFAULT CURRENT_TIMESTAMP)";
 
 	for key in pairs(sqlCreate) do
 		ExecuteStatement(sqlCreate[key]);

--- a/src/database.lua
+++ b/src/database.lua
@@ -4,7 +4,7 @@ function CreateDatabase()
 	sqlCreate[1] = "CREATE TABLE IF NOT EXISTS towns (town_id INTEGER PRIMARY KEY AUTOINCREMENT, town_name STRING NOT NULL UNIQUE, town_owner STRING NOT NULL UNIQUE, nation_id INTEGER, town_explosions_enabled INTEGER, town_pvp_enabled INTEGER)";
 	sqlCreate[2] = "CREATE TABLE IF NOT EXISTS townChunks (townChunk_id INTEGER PRIMARY KEY, town_id INTEGER, chunkX INTEGER, chunkZ INTEGER)";
 	sqlCreate[3] = "CREATE TABLE IF NOT EXISTS residents (player_uuid STRING UNIQUE, player_name STRING UNIQUE, town_id INTEGER, town_rank STRING, last_online INTEGER)";
-	sqlCreate[4] = "CREATE TABLE IF NOT EXISTS nations (nation_id INTEGER PRIMARY KEY AUTOINCREMENT, nation_name TEXT NOT NULL UNIQUE, nation_capital INTEGER NOT NULL UNIQUE)"
+	sqlCreate[4] = "CREATE TABLE IF NOT EXISTS nations (nation_id INTEGER PRIMARY KEY AUTOINCREMENT, nation_name STRING NOT NULL UNIQUE, nation_capital INTEGER NOT NULL UNIQUE)"
 	sqlCreate[5] = "CREATE TABLE IF NOT EXISTS invitations (invitation_id INTEGER PRIMARY KEY, player_uuid STRING, town_id INTEGER, invitation_date DATETIME DEFAULT CURRENT_TIMESTAMP)";
 
 	for key in pairs(sqlCreate) do

--- a/src/main.lua
+++ b/src/main.lua
@@ -5,7 +5,6 @@ function Initialize(Plugin)
 	PLUGIN:SetName("Townvalds");
 	PLUGIN:SetVersion(1);
 
-	LOG("Initialized " .. PLUGIN:GetName() .. " v." .. PLUGIN:GetVersion());
 	-- Load the Info shared library:
 	dofile(cPluginManager:GetPluginsPath() .. "/InfoReg.lua");
 
@@ -21,24 +20,33 @@ function Initialize(Plugin)
 	cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_PLACING_BLOCK, OnPlayerPlacingBlock);
 	cPluginManager.AddHook(cPluginManager.HOOK_EXPLODING, OnExploding);
 	cPluginManager.AddHook(cPluginManager.HOOK_CHAT, OnChat);
-    cPluginManager.AddHook(cPluginManager.HOOK_TAKE_DAMAGE, OnTakeDamage);
+	cPluginManager.AddHook(cPluginManager.HOOK_TAKE_DAMAGE, OnTakeDamage);
 
-    ini = cIniFile();
+	ini = cIniFile();
 
-    LoadConfig();
+	--Create a new config if this is the first load, otherwise load the existing config file
+	LoadConfig();
 
+	--Create a new database if this is the first load, otherwise open the existing one
 	if not (cFile:IsFile(PLUGIN:GetLocalFolder() .. cFile:GetPathSeparator() .. config.dbname)) then -- If true, means database is deleted, or the plugin runs for the first time
-       LOG("[" .. PLUGIN:GetName() .. "] It looks like this is the first time running this plugin. Creating database...")
-       db = sqlite3.open(PLUGIN:GetLocalFolder() .. cFile:GetPathSeparator() .. config.dbname);
-       CreateDatabase()
+		LOG("[" .. PLUGIN:GetName() .. "] It looks like this is the first time running this plugin. Creating database...")
+		db = sqlite3.open(PLUGIN:GetLocalFolder() .. cFile:GetPathSeparator() .. config.dbname);
+		CreateDatabase()
 	else
-       db = sqlite3.open(PLUGIN:GetLocalFolder() .. cFile:GetPathSeparator() .. config.dbname);
+		LOG("[" .. PLUGIN:GetName() .. "] Opening database");
+		db = sqlite3.open(PLUGIN:GetLocalFolder() .. cFile:GetPathSeparator() .. config.dbname);
 	end
 
+	--Compare existing nations to nations existing in the database and sync the two
+	LOG("[" .. PLUGIN:GetName() .. "] Syncing nations with the database");
+	NationSync();
+
+
+	LOG("[" .. PLUGIN:GetName() .. "] Initialized " .. PLUGIN:GetName() .. " v." .. PLUGIN:GetVersion());
 	return true;
 end
 
 function OnDisable() -- Gets called when the plugin is unloaded, mostly when shutting down the server
-   LOG("[" .. PLUGIN:GetName() .. "] Disabling " .. PLUGIN:GetName() .. " v" .. PLUGIN:GetVersion());
-   db:close();
+	LOG("[" .. PLUGIN:GetName() .. "] Disabling " .. PLUGIN:GetName() .. " v" .. PLUGIN:GetVersion());
+	db:close();
 end

--- a/src/nations.lua
+++ b/src/nations.lua
@@ -1,0 +1,167 @@
+--Syncs existing nations with nations in the database
+function NationSync()
+	cRoot:Get():ForEachWorld(
+	function (cWorld)
+		local scoreboard = cWorld:GetScoreBoard();
+
+		local sql = "SELECT nation_name FROM nations";
+		local result = ExecuteStatement(sql);
+
+		if not (result == nil) then
+			for key, value in pairs(result) do
+				if (scoreboard:GetTeam(value[1]) == nil) then
+					scoreboard:RegisterTeam(value[1], value[1], "", "");
+				end
+			end
+		end
+
+		local existingTeams = scoreboard:GetTeamNames();
+		for key, value in pairs(existingTeams) do
+
+			if not (result == nil) then
+				local inDatabase = false;
+
+				for dbKey, dbValue in pairs(result) do
+					if(dbValue[1] == value) then
+						inDatabase = true;
+					end
+				end
+
+				if(inDatabase == false) then
+					scoreboard:RemoveTeam(value);
+				end
+			else
+				scoreboard:RemoveTeam(value);
+			end
+		end
+	end
+	);
+
+	return true;
+end
+
+
+--Creates a new nation
+function NationCreate(Split, Player)
+	local sql = "SELECT town_id FROM towns WHERE town_owner = ?";
+	local parameter = {cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true)};
+	local town_id = ExecuteStatement(sql, parameter)[1][1];
+
+	if (town_id == nil) then
+		Player:SendMessageFailure("You can not create a nation if you're not the owner of a town!");
+	else
+		local sql = "SELECT nation_id FROM towns WHERE town_id = ?";
+		local parameter = {town_id};
+		local nation_id = ExecuteStatement(sql, parameter)[1][1];
+
+		if(nation_id == nil) then
+			local sql = "INSERT INTO nations (nation_name, nation_capital) VALUES (?, ?)";
+			local parameters = {Split[3], town_id};
+			local nation_id = ExecuteStatement(sql, parameters);
+
+			local sql = "UPDATE towns SET nation_id = ? WHERE town_id = ?";
+			local parameters = {nation_id, town_id};
+			ExecuteStatement(sql, parameters);
+
+			cRoot:Get():ForEachWorld(
+			function(cWorld)
+				cWorld:GetScoreBoard():RegisterTeam(Split[3], Split[3], "", "");
+			end
+			);
+
+			Player:SendMessageSuccess("Created a new nation called " .. Split[3]);
+		else
+			Player:SendMessageFailure("Your town is already part of a nation!");
+		end
+	end
+	return true;
+end
+
+--Removes the player's town from the nation
+LeavingNation = {};
+function NationLeave(Split, Player)
+	local UUID = cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true);
+	local sql = "SELECT town_id FROM residents WHERE player_uuid = ?";
+	local parameter = {UUID};
+	local town_id = ExecuteStatement(sql, parameter)[1][1];
+
+	if(town_id == nil) then
+		Player:SendMessageFailure("You can not leave nation if you're not part of a town!");
+	else
+		local sql = "SELECT town_owner, nation_id FROM towns WHERE town_id = ?";
+		local parameter = {town_id};
+		local town = ExecuteStatement(sql, parameter)[1];
+
+		if(town[1] == nil) then
+			Player:SendMessageFailure("You can not leave a nation if you're not the owner of a town!");
+		elseif(town[2] == nil) then
+			Player:SendMessageFailure("Your town is not part of a nation!");
+		else
+			local sql = "SELECT COUNT(*) FROM towns WHERE nation_id = ?";
+			local parameter = {town[2]};
+			local townInNationCount = ExecuteStatement(sql, parameter)[1][1];
+
+			if not (LeavingNation[UUID] == nil) then --The mayor wants to leave the nation
+				local sql = "SELECT nation_name FROM nations WHERE nation_id = ?";
+				local parameter = {town[2]};
+				local nationName = ExecuteStatement(sql, parameter)[1][1];
+
+				if(townInNationCount == 1) then
+					local sql = "UPDATE towns SET nation_id = NULL WHERE town_owner = ?";
+					local parameter = {UUID};
+					ExecuteStatement(sql, parameter);
+
+					local sql = "DELETE FROM nations WHERE nation_id = ?";
+					local parameter = {town[2]};
+					ExecuteStatement(sql, parameter);
+
+					--Delete the nation from each world's team list
+					cRoot:Get():ForEachWorld(
+					function(cWorld)
+						cWorld:GetScoreBoard():RemoveTeam(nationName);
+					end
+					);
+
+					Player:GetWorld():BroadcastChatInfo("The nation " .. nationName .. " was abandoned!");
+				else
+					local sql = "UPDATE towns SET nation_id = NULL WHERE town_id = ?";
+					local parameter = {town_id};
+					ExecuteStatement(sql, parameter);
+
+					Player:SendMessageSuccess("Your town left the nation");
+				end
+				LeavingNation[UUID] = nil;
+			else
+				if(townInNationCount == 1) then
+					Player:SendMessageInfo("Since your town is the last member of this nation, leaving it will cause it to be removed.");
+					Player:SendMessageInfo("Use `/nation leave` again if you wish to continue.");
+				else
+					Player:SendMessageInfo("Are you sure you want your town to leave the nation?");
+					Player:SendMessageInfo("Use `/nation leave` again if you wish to continue.");
+				end
+
+				LeavingNation[UUID] = true;
+			end
+		end
+	end
+
+	return true;
+end
+
+
+--Prints a list of nations to the player
+function NationList(Split, Player)
+	--Get nations from world instead of database to save queries
+	--Since nations are always synced between worlds, this should work properly at all times
+	local nations = Player:GetWorld():GetScoreBoard():GetTeamNames();
+	if not (next(nations) == nil) then
+		Player:SendMessageInfo("[ Nations ]");
+		for key, value in pairs(nations) do
+			Player:SendMessageInfo(value);
+		end
+	else
+		Player:SendMessageInfo("There are no nations yet!");
+	end
+
+	return true;
+end

--- a/src/nations.lua
+++ b/src/nations.lua
@@ -24,6 +24,7 @@ function NationSync()
 				for dbKey, dbValue in pairs(result) do
 					if(dbValue[1] == value) then
 						inDatabase = true;
+						break;
 					end
 				end
 


### PR DESCRIPTION
Added initial nation support. Currently it's possible to create a nation (as the town mayor), leave one, or list all nations. If the leaving town is the last town in the nation, the whole nation will be deleted.

This uses the Minecraft teams feature, so eventually we can toggle pvp per "team" or "nation", and spectral arrows and such will show the team color when shot. Nations are added for each world seperately and removed as well. At each plugin reload, the Minecraft team list is "synced" with the database to reflect changes done externally.

Also fixed some ident issues in some files.

Resolves #36 and partially #30
