### PR TITLE
Added toggleable mob spawning in towns and plots

### DIFF
--- a/src/Info.lua
+++ b/src/Info.lua
@@ -123,7 +123,13 @@ g_PluginInfo =
 							Handler = TownTogglePVP,
 							HelpString = "Toggles PVP in the current town",
 							Permission = "townvalds.town.toggle"
-						}
+						},
+						mobs =
+						{
+							Handler = TownToggleMobs,
+							HelpString = "Toggles mob spawning in the current town",
+							Permission = "townvalds.town.toggle"
+						},
 					}
 				},
 				list =
@@ -138,6 +144,24 @@ g_PluginInfo =
 					HelpString = "Lists available ranks, or grant and remove a rank to a resident of the town",
 					Permission = "townvalds.town.rank",
 				},
+			}
+		},
+		["/plot"] =
+		{
+			Subcommands =
+			{
+				["toggle"] =
+				{
+					Subcommands =
+					{
+						mobs =
+						{
+							Handler = PlotToggleMobs,
+							HelpString = "Toggles mob spawning in the current plot",
+							Permission = "townvalds.plot.toggle"
+						}
+					}
+				}
 			}
 		},
 		["/resident"] =
@@ -239,6 +263,16 @@ g_PluginInfo =
 		["townvalds.town.rank"] =
 		{
 			Description = "Lists available ranks, or grant and remove a rank to a resident of the town",
+			RecommendedGroups = "default",
+		},
+		["townvalds.town.toggle"] =
+		{
+			Description = "Allows the player to toggle town features",
+			RecommendedGroups = "default",
+		},
+		["townvalds.plot.toggle"] =
+		{
+			Description = "Allows the player to toggle plot features",
 			RecommendedGroups = "default",
 		},
 		["townvalds.chat.switch"] =

--- a/src/database.lua
+++ b/src/database.lua
@@ -1,8 +1,8 @@
 function CreateDatabase()
 	-- Create tables
 	local sqlCreate = {};
-	sqlCreate[1] = "CREATE TABLE IF NOT EXISTS towns (town_id INTEGER PRIMARY KEY AUTOINCREMENT, town_name STRING NOT NULL UNIQUE, town_owner STRING NOT NULL UNIQUE, nation_id INTEGER, town_explosions_enabled INTEGER, town_pvp_enabled INTEGER)";
-	sqlCreate[2] = "CREATE TABLE IF NOT EXISTS townChunks (townChunk_id INTEGER PRIMARY KEY, town_id INTEGER, chunkX INTEGER, chunkZ INTEGER)";
+	sqlCreate[1] = "CREATE TABLE IF NOT EXISTS towns (town_id INTEGER PRIMARY KEY AUTOINCREMENT, town_name STRING NOT NULL UNIQUE, town_owner STRING NOT NULL UNIQUE, nation_id INTEGER, town_explosions_enabled INTEGER DEFAULT 0, town_pvp_enabled INTEGER DEFAULT 0, town_mobs_enabled INTEGER DEFAULT 0)";
+	sqlCreate[2] = "CREATE TABLE IF NOT EXISTS townChunks (townChunk_id INTEGER PRIMARY KEY, town_id INTEGER, chunkX INTEGER, chunkZ INTEGER, plot_mobs_enabled INTEGER DEFAULT 2)";
 	sqlCreate[3] = "CREATE TABLE IF NOT EXISTS residents (player_uuid STRING UNIQUE, player_name STRING UNIQUE, town_id INTEGER, town_rank STRING, last_online INTEGER)";
 	sqlCreate[4] = "CREATE TABLE IF NOT EXISTS nations (nation_id INTEGER PRIMARY KEY AUTOINCREMENT, nation_name STRING NOT NULL UNIQUE, nation_capital INTEGER NOT NULL UNIQUE)"
 	sqlCreate[5] = "CREATE TABLE IF NOT EXISTS invitations (invitation_id INTEGER PRIMARY KEY, player_uuid STRING, town_id INTEGER, invitation_date DATETIME DEFAULT CURRENT_TIMESTAMP)";

--- a/src/main.lua
+++ b/src/main.lua
@@ -21,6 +21,7 @@ function Initialize(Plugin)
 	cPluginManager.AddHook(cPluginManager.HOOK_EXPLODING, OnExploding);
 	cPluginManager.AddHook(cPluginManager.HOOK_CHAT, OnChat);
 	cPluginManager.AddHook(cPluginManager.HOOK_TAKE_DAMAGE, OnTakeDamage);
+	cPluginManager.AddHook(cPluginManager.HOOK_SPAWNING_MONSTER, OnSpawningMonster);
 
 	ini = cIniFile();
 

--- a/src/plots.lua
+++ b/src/plots.lua
@@ -1,52 +1,66 @@
 function PlotToggleMobs(Split, Player)
 	local UUID = cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true);
 
-	local sql = "SELECT towns.town_mobs_enabled, townChunks.plot_mobs_enabled FROM towns INNER JOIN townChunks ON towns.town_id = townChunks.town_id WHERE townChunks.chunkX = ? AND townChunks.chunkZ = ?";
-	local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
-	local plot = ExecuteStatement(sql, parameters)[1];
+	local sql = "SELECT town_id FROM residents WHERE player_uuid = ?";
+	local parameter = {UUID};
+	local town_id = ExecuteStatement(sql, parameter)[1][1];
 
-	local toggle;
-	if(plot == nil) then
-		Player:SendMessageFailure("You have to be in a plot to toggle it's features");
+	if (town_id == nil) then
+		Player:SendMessageFailure("You can't toggle if you're not part of a town");
+		return true;
 	else
-		if not(Split[4] == nil) then --The user wants the plot to inherit the town value
-			if not(Split[4] == "inherit") then
-				Player:SendMessageFailure("This argument is not understood");
-				return true;
-			else
-				toggle = 2;
-			end
+		local sql = "SELECT towns.town_id, towns.town_owner, towns.town_mobs_enabled, townChunks.plot_mobs_enabled FROM towns INNER JOIN townChunks ON towns.town_id = townChunks.town_id WHERE townChunks.chunkX = ? AND townChunks.chunkZ = ?";
+		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
+		local plot = ExecuteStatement(sql, parameters)[1];
+
+		local toggle;
+		if(plot == nil) then
+			Player:SendMessageFailure("You have to be in a plot to toggle it's features");
+			return true;
+		elseif not(plot[2] == UUID) then
+			Player:SendMessageFailure("You can't toggle if you're not the owner of the town");
+			return true;
 		else
-			if(plot[2] == 2 and plot[1] == 1) then --plot[2] at 2 means it inherits the town status
-				toggle = 0;
-			elseif(plot[2] == 2 and plot[1] == 0) then
-				toggle = 1;
-			elseif(plot[2] == 1) then
-				toggle = 0;
+			if not(Split[4] == nil) then --The user wants the plot to inherit the town value
+				if not(Split[4] == "inherit") then
+					Player:SendMessageFailure("This argument is not understood, you probably meant");
+					return true;
+				else
+					toggle = 2;
+				end
 			else
-				toggle = 1;
+				if(plot[4] == 2 and plot[3] == 1) then --plot[2] at 2 means it inherits the town status
+					toggle = 0;
+				elseif(plot[4] == 2 and plot[3] == 0) then
+					toggle = 1;
+				elseif(plot[4] == 1) then
+					toggle = 0;
+				else
+					toggle = 1;
+				end
 			end
 		end
+
+		if(toggle == 2) then --The user wants the plot to inherit the town value
+			local sql = "UPDATE townChunks SET plot_mobs_enabled = 2 WHERE chunkX = ? AND chunkZ = ?";
+			local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
+			ExecuteStatement(sql, parameters);
+
+			Player:SendMessageSuccess("Mob spawning now inherits the town value");
+		elseif(toggle == 1) then --The user wants the plot to have mob spawning enabled
+			local sql = "UPDATE townChunks SET plot_mobs_enabled = 1 WHERE chunkX = ? AND chunkZ = ?";
+			local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
+			ExecuteStatement(sql, parameters);
+
+			Player:SendMessageSuccess("Mob spawning is now enabled in this plot");
+		else --The user wants the plot to have mob spawning disabled
+			local sql = "UPDATE townChunks SET plot_mobs_enabled = 0 WHERE chunkX = ? AND chunkZ = ?";
+			local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
+			ExecuteStatement(sql, parameters);
+
+			Player:SendMessageSuccess("Mob spawning is now disabled in this plot");
+		end
+
+		return true;
 	end
-
-	if(toggle == 2) then --The user wants the plot to inherit the town value
-		local sql = "UPDATE townChunks SET plot_mobs_enabled = 2 WHERE chunkX = ? AND chunkZ = ?";
-		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
-		ExecuteStatement(sql, parameters);
-
-		Player:SendMessageSuccess("Mob spawning now inherits the town value");
-	elseif(toggle == 1) then --The user wants the plot to have mob spawning enabled
-		local sql = "UPDATE townChunks SET plot_mobs_enabled = 1 WHERE chunkX = ? AND chunkZ = ?";
-		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
-		ExecuteStatement(sql, parameters);
-
-		Player:SendMessageSuccess("Mob spawning is now enabled in this plot");
-	else --The user wants the plot to have mob spawning disabled
-		local sql = "UPDATE townChunks SET plot_mobs_enabled = 0 WHERE chunkX = ? AND chunkZ = ?";
-		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
-		ExecuteStatement(sql, parameters);
-
-		Player:SendMessageSuccess("Mob spawning is now disabled in this plot");
-	end
-	return true;
 end

--- a/src/plots.lua
+++ b/src/plots.lua
@@ -1,0 +1,52 @@
+function PlotToggleMobs(Split, Player)
+	local UUID = cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true);
+
+	local sql = "SELECT towns.town_mobs_enabled, townChunks.plot_mobs_enabled FROM towns INNER JOIN townChunks ON towns.town_id = townChunks.town_id WHERE townChunks.chunkX = ? AND townChunks.chunkZ = ?";
+	local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
+	local plot = ExecuteStatement(sql, parameters)[1];
+
+	local toggle;
+	if(plot == nil) then
+		Player:SendMessageFailure("You have to be in a plot to toggle it's features");
+	else
+		if not(Split[4] == nil) then --The user wants the plot to inherit the town value
+			if not(Split[4] == "inherit") then
+				Player:SendMessageFailure("This argument is not understood");
+				return true;
+			else
+				toggle = 2;
+			end
+		else
+			if(plot[2] == 2 and plot[1] == 1) then --plot[2] at 2 means it inherits the town status
+				toggle = 0;
+			elseif(plot[2] == 2 and plot[1] == 0) then
+				toggle = 1;
+			elseif(plot[2] == 1) then
+				toggle = 0;
+			else
+				toggle = 1;
+			end
+		end
+	end
+
+	if(toggle == 2) then --The user wants the plot to inherit the town value
+		local sql = "UPDATE townChunks SET plot_mobs_enabled = 2 WHERE chunkX = ? AND chunkZ = ?";
+		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
+		ExecuteStatement(sql, parameters);
+
+		Player:SendMessageSuccess("Mob spawning now inherits the town value");
+	elseif(toggle == 1) then --The user wants the plot to have mob spawning enabled
+		local sql = "UPDATE townChunks SET plot_mobs_enabled = 1 WHERE chunkX = ? AND chunkZ = ?";
+		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
+		ExecuteStatement(sql, parameters);
+
+		Player:SendMessageSuccess("Mob spawning is now enabled in this plot");
+	else --The user wants the plot to have mob spawning disabled
+		local sql = "UPDATE townChunks SET plot_mobs_enabled = 0 WHERE chunkX = ? AND chunkZ = ?";
+		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
+		ExecuteStatement(sql, parameters);
+
+		Player:SendMessageSuccess("Mob spawning is now disabled in this plot");
+	end
+	return true;
+end

--- a/src/plots.lua
+++ b/src/plots.lua
@@ -23,7 +23,7 @@ function PlotToggleMobs(Split, Player)
 		else
 			if not(Split[4] == nil) then --The user wants the plot to inherit the town value
 				if not(Split[4] == "inherit") then
-					Player:SendMessageFailure("This argument is not understood, you probably meant");
+					Player:SendMessageFailure("This argument is not understood");
 					return true;
 				else
 					toggle = 2;

--- a/src/plots.lua
+++ b/src/plots.lua
@@ -29,7 +29,7 @@ function PlotToggleMobs(Split, Player)
 					toggle = 2;
 				end
 			else
-				if(plot[4] == 2 and plot[3] == 1) then --plot[2] at 2 means it inherits the town status
+				if(plot[4] == 2 and plot[3] == 1) then --plot[4] at 2 means it inherits the town status
 					toggle = 0;
 				elseif(plot[4] == 2 and plot[3] == 0) then
 					toggle = 1;

--- a/src/toggle.lua
+++ b/src/toggle.lua
@@ -12,27 +12,47 @@ function OnExploding(World, ExplosionSize, CanCauseFire, X, Y, Z, Source, Source
 end
 
 function OnTakeDamage(Receiver, TDI)
-    if Receiver:IsPlayer() and TDI.Attacker ~= nil and TDI.Attacker:IsPlayer() then
-        attacker_result = 1
-        receiver_result = 1
-        local town_sql = "SELECT town_id FROM townChunks WHERE chunkX = ? AND chunkZ = ?";
-        local pvp_sql = "SELECT town_pvp_enabled FROM towns WHERE town_id = ?";
+	if Receiver:IsPlayer() and TDI.Attacker ~= nil and TDI.Attacker:IsPlayer() then
+		attacker_result = 1
+		receiver_result = 1
+		local town_sql = "SELECT town_id FROM townChunks WHERE chunkX = ? AND chunkZ = ?";
+		local pvp_sql = "SELECT town_pvp_enabled FROM towns WHERE town_id = ?";
 
-        local attacker_parameters = {TDI.Attacker:GetChunkX(), TDI.Attacker:GetChunkZ()};
-        local receiver_parameters = {Receiver:GetChunkX(), Receiver:GetChunkZ()};
+		local attacker_parameters = {TDI.Attacker:GetChunkX(), TDI.Attacker:GetChunkZ()};
+		local receiver_parameters = {Receiver:GetChunkX(), Receiver:GetChunkZ()};
 
-        if ExecuteStatement(town_sql, attacker_parameters)[1] ~= nil then
-            local attacker_town_id = ExecuteStatement(town_sql, attacker_parameters)[1][1];
-            attacker_result = ExecuteStatement(pvp_sql, {attacker_town_id})[1][1];
-        end
+		if ExecuteStatement(town_sql, attacker_parameters)[1] ~= nil then
+			local attacker_town_id = ExecuteStatement(town_sql, attacker_parameters)[1][1];
+			attacker_result = ExecuteStatement(pvp_sql, {attacker_town_id})[1][1];
+		end
 
-        if ExecuteStatement(town_sql, receiver_parameters)[1] ~= nil then
-            local receiver_town_id = ExecuteStatement(town_sql, receiver_parameters)[1][1];
-            receiver_result = ExecuteStatement(pvp_sql, {receiver_town_id})[1][1];
-        end
+		if ExecuteStatement(town_sql, receiver_parameters)[1] ~= nil then
+			local receiver_town_id = ExecuteStatement(town_sql, receiver_parameters)[1][1];
+			receiver_result = ExecuteStatement(pvp_sql, {receiver_town_id})[1][1];
+		end
 
-        if attacker_result == 0 or receiver_result == 0 then
-            return true;
-        end
-    end
+		if attacker_result == 0 or receiver_result == 0 then
+			return true;
+		end
+	end
+end
+
+function OnSpawningMonster(World, Monster)
+	if(Monster:GetMobFamily() == 0) then --Check if the monster is hostile
+		local sql = "SELECT towns.town_mobs_enabled, townChunks.plot_mobs_enabled FROM towns INNER JOIN townChunks ON towns.town_id = townChunks.town_id WHERE townChunks.chunkX = ? AND townChunks.chunkZ = ?";
+		local parameters = {Monster:GetChunkX(), Monster:GetChunkZ()};
+		local town = ExecuteStatement(sql, parameters)[1];
+
+		if not(town == nil) then --Check if the mob is in a town chunk
+			if(town[2] == 2) then --The chunk inherit it's mob spawning property from the town
+				if(town[1] == 0) then --Check if mob spawning is allowed
+					return true;
+				end
+			elseif(town[2] == 0) then
+				return true;
+			end
+		end
+	end
+
+	return false;
 end

--- a/src/towns.lua
+++ b/src/towns.lua
@@ -275,7 +275,7 @@ function TownToggleExplosions(Split, Player)
 		local sql = "SELECT town_id FROM townChunks WHERE chunkX = ? AND chunkZ = ?";
 		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
 		local result = ExecuteStatement(sql, parameters)[1][1];
-		
+
 		if(town_id == result) then
 			local sql = "SELECT town_explosions_enabled FROM towns WHERE town_id = ?";
 			local parameters = {town_id};
@@ -392,7 +392,7 @@ function TownTogglePVP(Split, Player)
 		local sql = "SELECT town_id FROM townChunks WHERE chunkX = ? AND chunkZ = ?";
 		local parameters = {Player:GetChunkX(), Player:GetChunkZ()};
 		local result = ExecuteStatement(sql, parameters)[1][1];
-		
+
 		if(town_id == result) then
 			local sql = "SELECT town_pvp_enabled FROM towns WHERE town_id = ?";
 			local parameters = {town_id};
@@ -414,6 +414,33 @@ function TownTogglePVP(Split, Player)
 		end
 	else
 		Player:SendMessageFailure("You can't toggle if you're not in a town!");
+	end
+	return true;
+end
+
+function TownToggleMobs(Split, Player)
+	local UUID = cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true);
+
+	local sql = "SELECT town_id, town_mobs_enabled FROM towns WHERE town_owner = ?";
+	local parameter = {UUID};
+	local town = ExecuteStatement(sql, parameter)[1];
+
+	if(town == nil) then
+		Player:SendMessageFailure("You can't toggle if you're not the owner of a town!");
+	else
+		if(town[2] == 0) then
+			local sql = "UPDATE towns SET town_mobs_enabled = 1 WHERE town_id = ?";
+			local parameter = {town[1]};
+			ExecuteStatement(sql, parameter);
+
+			Player:SendMessageSuccess("Mob spawning enabled");
+		else
+			local sql = "UPDATE towns SET town_mobs_enabled = 0 WHERE town_id = ?";
+			local parameter = {town[1]};
+			ExecuteStatement(sql, parameter);
+
+			Player:SendMessageSuccess("Mob spawning disabled");
+		end
 	end
 	return true;
 end

--- a/src/towns.lua
+++ b/src/towns.lua
@@ -421,14 +421,16 @@ end
 function TownToggleMobs(Split, Player)
 	local UUID = cMojangAPI:GetUUIDFromPlayerName(Player:GetName(), true);
 
-	local sql = "SELECT town_id, town_mobs_enabled FROM towns WHERE town_owner = ?";
+	local sql = "SELECT towns.town_id, towns.town_owner, towns.town_mobs_enabled FROM towns INNER JOIN residents ON towns.town_id = residents.town_id WHERE residents.player_uuid = ?";
 	local parameter = {UUID};
 	local town = ExecuteStatement(sql, parameter)[1];
 
 	if(town == nil) then
+		Player:SendMessageFailure("You can't toggle if you're not part of a town!");
+	elseif not(town[2] == UUID) then
 		Player:SendMessageFailure("You can't toggle if you're not the owner of a town!");
 	else
-		if(town[2] == 0) then
+		if(town[3] == 0) then
 			local sql = "UPDATE towns SET town_mobs_enabled = 1 WHERE town_id = ?";
 			local parameter = {town[1]};
 			ExecuteStatement(sql, parameter);


### PR DESCRIPTION
Mob spawning can now be disabled per town, or per plot. The plot value always overrides the town value, to give the player more control. The plot by default inherits the town value, and can also be set to inherit the town again later on using `/plot toggle mobs inherit`.

This resolves #29
