### PR TITLE
Bringing chat up to par with the rest of the plugin

### DIFF
--- a/src/Info.lua
+++ b/src/Info.lua
@@ -184,7 +184,7 @@ g_PluginInfo =
 		},
 		["/switchchat"] =
 		{
-			Alias = {"/sc", "/gc", "/tc", "/lc"},
+			Alias = {"/sc", "/gc", "/nc", "/tc", "/lc"},
 			Handler = SwitchChat,
 			HelpString = "Switches the active chat channel for the user",
 			Permission = "townvalds.chat.switch",

--- a/src/chat.lua
+++ b/src/chat.lua
@@ -5,12 +5,8 @@ function OnChat(Player, Message)
 
 		--If the player is in the specified channel, send it to the players having that channel active
 		if(Channel[UUID] == "nation") then --Nation channel
-			local sql = "SELECT nations.nation_id FROM nations INNER JOIN towns ON nations.nation_id = towns.nation_id INNER JOIN residents ON towns.town_id = residents.town_id WHERE player_uuid = ?";
+			local sql = "SELECT residents.player_uuid FROM residents INNER JOIN towns ON residents.town_id = towns.town_id WHERE towns.nation_id = (SELECT nations.nation_id FROM nations INNER JOIN towns ON nations.nation_id = towns.nation_id INNER JOIN residents ON towns.town_id = residents.town_id WHERE residents.player_uuid = ?)";
 			local parameter = {UUID};
-			local nation = ExecuteStatement(sql, parameter)[1];
-
-			local sql = "SELECT player_uuid FROM residents INNER JOIN towns ON residents.town_id = towns.town_id WHERE towns.nation_id = ?";
-			local parameter = {nation[1]};
 			local players = ExecuteStatement(sql, parameter);
 
 			for key, value in pairs(players) do
@@ -21,13 +17,9 @@ function OnChat(Player, Message)
 				);
 			end
 		elseif(Channel[UUID] == "town") then --Town channel
-			sql = "SELECT town_id FROM residents WHERE player_uuid = ?";
-			parameter = {UUID};
-			local town_id = ExecuteStatement(sql, parameter)[1][1];
-
-			sql = "SELECT player_uuid FROM residents WHERE town_id = ?";
-			parameters = {town_id};
-			local players = ExecuteStatement(sql, parameters);
+			local sql = "SELECT player_uuid FROM residents WHERE town_id = (SELECT town_id FROM residents WHERE player_uuid = ?)";
+			local parameter = {UUID};
+			local players = ExecuteStatement(sql, parameter);
 
 			for key, value in pairs(players) do
 				player = cRoot:Get():DoWithPlayerByUUID(value[1],

--- a/src/nations.lua
+++ b/src/nations.lua
@@ -95,6 +95,16 @@ function NationLeave(Split, Player)
 		local townInNationCount = ExecuteStatement(sql, parameter)[1][1];
 
 		if not (LeavingNation[UUID] == nil) then --The mayor wants to leave the nation
+			local sql = "SELECT player_uuid FROM residents WHERE town_id = ?";
+			local parameter = {town[1]};
+			local players = ExecuteStatement(sql, parameter);
+
+			for key, value in pairs(players) do
+				if (Channel[value[1]] == "nation") then
+					Channel[value[1]] = "town";
+				end
+			end
+
 			local sql = "SELECT nation_name FROM nations WHERE nation_id = ?";
 			local parameter = {town[3]};
 			local nationName = ExecuteStatement(sql, parameter)[1][1];

--- a/src/towns.lua
+++ b/src/towns.lua
@@ -260,6 +260,10 @@ function TownLeave(Split, Player)
 
 			Leaving[UUID] = nil;
 
+			if(Channel[UUID] == "town" or Channel[UUID] == "nation") then
+				Channel[UUID] = "global";
+			end
+
 			return true;
 		else
 			sql = "SELECT player_name FROM residents WHERE town_id = ?";


### PR DESCRIPTION
- Adds nation chat. Chat send in this channel will only be send to people in the same nation as the sender
- Switches conditional statements to have the failure case first, and succesful cases afterwards like the other commits recently
- Switched chat functions around to have the channels with the biggest range on top, smallest on bottom. So currently global, nation, town, local. This applies everywhere in chat.lua
- Players will now be reset to global chat if they are in the town channel when leaving a town
- Players will now be reset to town chat if they are in the nation channel when their town leaves a nation
