### PR TITLE
Add checks to see if explosion borders town

### DIFF
--- a/src/toggle.lua
+++ b/src/toggle.lua
@@ -1,12 +1,21 @@
 function OnExploding(World, ExplosionSize, CanCauseFire, X, Y, Z, Source, SourceData)
 	local town_sql = "SELECT town_id FROM townChunks WHERE chunkX = ? AND chunkZ = ? AND world = ?";
 	local town_parameters = {math.floor(X/16), math.floor(Z/16), World:GetName()};
-	if ExecuteStatement(town_sql, town_parameters)[1] ~= nil then
-		local town_id = ExecuteStatement(town_sql, town_parameters)[1][1];
-		local explosion_sql = "SELECT town_explosions_enabled FROM towns WHERE town_id = ?";
-		local explosion_parameters = {town_id};
-		if ExecuteStatement(explosion_sql, explosion_parameters)[1][1] == 0 then
-			return true;
+	
+	for a = -1, 1, 1 do
+		for b = -1, 1, 1 do
+			town_parameters[1] = town_parameters[1] + a
+			town_parameters[2] = town_parameters[2] + b
+			if ExecuteStatement(town_sql, town_parameters)[1] ~= nil then
+				local town_id = ExecuteStatement(town_sql, town_parameters)[1][1];
+				local explosion_sql = "SELECT town_explosions_enabled FROM towns WHERE town_id = ?";
+				local explosion_parameters = {town_id};
+				if ExecuteStatement(explosion_sql, explosion_parameters)[1][1] == 0 then
+					return true;
+				end
+			end
+			town_parameters[1] = town_parameters[1] - a --reset chunks
+			town_parameters[2] = town_parameters[2] - b
 		end
 	end
 end


### PR DESCRIPTION
Adds a 1-chunk border around all towns and disables an explosion if the explosion is on this border.
Fixes #46 
