### PR TITLE
Prevent chunk unclaiming if that means a chunk next to it would be disconnected from the town

### DIFF
--- a/Info.lua
+++ b/Info.lua
@@ -2,7 +2,8 @@ g_PluginInfo =
 {
 	Name = "Townvalds",
 	Date = "2015-11-18",
-	Description = "An opensource town plugin, based on Towny (for Bukkit).",
+	SourceLocation = "https://github.com/linuxmasterrace/townvalds",
+	Description = "[[An open-source town plugin, based on Towny (for Bukkit)]]",
 
 	AdditionalInfo =
 	{


### PR DESCRIPTION
Currently this does not prevent chunk unclaiming if any chunk next to the one unclaimed is connected to other town chunks. This means a town can be split in 2 if a single chunk connects 2 parts, and the connecting chunk is unclaimed. This has to be looked into later on.
